### PR TITLE
Add unit tests for get_current_time

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,14 @@ SearchAPI-MCP-Server implements the Model Context Protocol, encapsulating variou
 * 设施和服务筛选 | Facilities and services filtering
 * 用户评分和评论 | User ratings and reviews
 * 特殊优惠查询 | Special offers query
+
 * 房型选择 | Room type selection
+
+### SearchAPI 新增功能 | Additional SearchAPI Features
+* SearchAPI Dashboard 与账号信息 | Dashboard and account management
+* 搜索历史记录查看 | View search history
+* 更多搜索引擎支持，如 Google Ads Transparency、Google Shopping、Google Images、Google News、Bing、Baidu、Naver、Yahoo、Amazon、Shein、eBay、Google Play Store、Apple App Store、DuckDuckGo、YouTube
+* 专用接口：Google Travel Explore、Google Hotels Autocomplete、Google Flights Location Search、Google Maps Photos、Google Maps Reviews、Google Maps Place
 
 ## 安装说明 | Installation
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -370,9 +370,17 @@ async def get_current_time(
     now = datetime.now()
     
     # 将字符串参数转换为对应的数据类型
-    days_offset_int = int(days_offset) if days_offset is not None else 0
+    try:
+        days_offset_int = int(days_offset) if days_offset is not None else 0
+    except (TypeError, ValueError):
+        return {"error": "days_offset must be an integer"}
+
     return_future_dates_bool = return_future_dates.lower() == "true" if return_future_dates is not None else False
-    future_days_int = int(future_days) if future_days is not None else 7
+
+    try:
+        future_days_int = int(future_days) if future_days is not None else 7
+    except (TypeError, ValueError):
+        return {"error": "future_days must be an integer"}
     
     target_date = now + timedelta(days=days_offset_int)
     

--- a/tests/test_get_current_time.py
+++ b/tests/test_get_current_time.py
@@ -1,0 +1,33 @@
+import unittest
+from unittest.mock import patch
+from datetime import datetime
+
+import mcp_server
+
+FIXED_NOW = datetime(2023, 1, 1, 12, 0, 0)
+
+class FixedDateTime(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return FIXED_NOW
+
+class GetCurrentTimeTests(unittest.IsolatedAsyncioTestCase):
+    async def test_default_output(self):
+        with patch('mcp_server.datetime', FixedDateTime):
+            result = await mcp_server.get_current_time()
+        self.assertEqual(result['date'], '2023-01-01')
+        self.assertEqual(result['target_date']['iso'], '2023-01-01')
+        self.assertEqual(result['now']['iso'], '2023-01-01')
+
+    async def test_non_zero_offset(self):
+        with patch('mcp_server.datetime', FixedDateTime):
+            result = await mcp_server.get_current_time(days_offset='3')
+        self.assertEqual(result['date'], '2023-01-04')
+        self.assertEqual(result['target_date']['iso'], '2023-01-04')
+
+    async def test_invalid_offset(self):
+        result = await mcp_server.get_current_time(days_offset='bad')
+        self.assertIn('error', result)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add tests folder with async tests for `get_current_time`
- improve error handling in `get_current_time`
- document extra SearchAPI features in README

## Testing
- `SEARCHAPI_API_KEY=dummy python -m unittest discover -s tests`